### PR TITLE
Fix for compilation error seen on gcc 9.3.0

### DIFF
--- a/common-raii.h
+++ b/common-raii.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <memory>
 #include <random>
 #include <string>
+#include <sstream>
 
 namespace commonRaii { // TODO: add valgrind tests for all raii classes
 


### PR DESCRIPTION
This is a fix for #1 

Just adding the required include for `sstream`